### PR TITLE
Upgrade Cocaine to Terrapin

### DIFF
--- a/lib/ext/string.rb
+++ b/lib/ext/string.rb
@@ -1,7 +1,7 @@
 class String
   def word_count
     begin
-      line = Cocaine::CommandLine.new("echo", ":str | wc -w")
+      line = Terrapin::CommandLine.new("echo", ":str | wc -w")
       line.run(:str => self.gsub('"', '\"').gsub('|', " ").gsub(" / ", " ").gsub(/[`\n]/, " ")).strip.to_i
     rescue
       return 0

--- a/lib/word_count.rb
+++ b/lib/word_count.rb
@@ -1,3 +1,3 @@
 require 'ext/string'
 require 'ext/hash'
-require 'cocaine'
+require 'terrapin'

--- a/word_count.gemspec
+++ b/word_count.gemspec
@@ -1,16 +1,16 @@
 # encoding: utf-8
 Gem::Specification.new do |s|
-  s.name        = "word_count" 
+  s.name        = "word_count"
   s.version     = "0.0.1"
   s.summary     = "Word Count"
   s.email       = "edouard@atelierconvivialite.com"
   s.homepage    = "https://webtranslateit.com"
   s.authors     = "Edouard Briere"
- 
+
   s.files       = Dir["history.md", "license", "readme.md", "lib/**/*"]
-    
-  s.add_dependency 'cocaine'
-  
+
+  s.add_dependency 'terrapin'
+
   s.add_development_dependency "rspec", ">= 2.8.0"
   s.add_development_dependency 'guard-rspec'
 


### PR DESCRIPTION
These two are functionally equivalent since Cocaine was renamed to Terrapin. This simply gets rid of some deprecation warnings when running any app that requires `word_count`.